### PR TITLE
Specify Version Tag For Alpine Base Image and propagate that to tags in built image

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -3,6 +3,10 @@ name: Create and publish a Docker image
 on:
   push:
     branches: ['main']
+  paths:
+    - "**.py"
+    - ".github/workflows/deploy-image.yml"
+    - "Dockerfile"
 
 env:
   REGISTRY: ghcr.io
@@ -22,6 +26,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Get Alpine version from Dockerfile
+        id: alpine
+        run: |
+          version=$(grep '^FROM alpine:' Dockerfile | cut -d':' -f2)
+          echo "version=$version" >> $GITHUB_OUTPUT
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -34,6 +44,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=alpine-${{ steps.alpine.outputs.version }}
 
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -29,8 +29,12 @@ jobs:
       - name: Get Alpine version from Dockerfile
         id: alpine
         run: |
-          version=$(grep '^FROM alpine:' Dockerfile | cut -d':' -f2)
-          echo "version=$version" >> $GITHUB_OUTPUT
+          full=$(grep '^FROM alpine:' Dockerfile | cut -d':' -f2)
+          major=$(echo $full | cut -d'.' -f1)
+          minor=$(echo $full | cut -d'.' -f2)
+          echo "full=$full" >> $GITHUB_OUTPUT
+          echo "major=$major" >> $GITHUB_OUTPUT
+          echo "major_minor=$major.$minor" >> $GITHUB_OUTPUT
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -46,7 +50,9 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest
-            type=raw,value=alpine-${{ steps.alpine.outputs.version }}
+            type=raw,value=alpine-${{ steps.alpine.outputs.full }}
+            type=raw,value=alpine-${{ steps.alpine.outputs.major_minor }}
+            type=raw,value=alpine-${{ steps.alpine.outputs.major }}
 
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -3,10 +3,10 @@ name: Create and publish a Docker image
 on:
   push:
     branches: ['main']
-  paths:
-    - "**.py"
-    - ".github/workflows/deploy-image.yml"
-    - "Dockerfile"
+    paths:
+      - "**.py"
+      - ".github/workflows/deploy-image.yml"
+      - "Dockerfile"
 
 env:
   REGISTRY: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.22.1
 
 RUN apk add --update --no-cache python3 py3-aiohttp
 


### PR DESCRIPTION
Be more explicit about which version of Alpine you're building on, this way we can use renovate to get updates to keep things secure. Similarly include alpine version tags in the built images so users can track which version they use more precisely